### PR TITLE
Add Jest testing framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node app.js"
   },
   "keywords": [],
@@ -32,7 +32,10 @@
     "passport-local-mongoose": "^6.0.1",
     "sanitize-html": "^1.27.4"
   },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
   "engines": {
-    "node": ">=0.12 < 17.5.0" 
+    "node": ">=0.12 < 17.5.0"
   }
 }

--- a/tests/utils/ExpressError.test.js
+++ b/tests/utils/ExpressError.test.js
@@ -1,0 +1,9 @@
+const ExpressError = require('../../utils/ExpressError');
+
+describe('ExpressError', () => {
+  test('sets message and statusCode', () => {
+    const err = new ExpressError('boom', 418);
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(418);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency
- switch test script to `jest`
- create basic test for ExpressError

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da61e85c48328be4b62afb55fc0ce