### PR TITLE
Fix seeding DB name

### DIFF
--- a/seeds/index.js
+++ b/seeds/index.js
@@ -3,7 +3,9 @@ const cities = require('./cities');
 const { places, descriptors } = require('./seedHelpers');
 const Campground = require('../models/campground');
 
-mongoose.connect('mongodb://localhost:27017/YelpCamp', {
+const dbUrl = process.env.DB_URL || 'mongodb://localhost:27017/in-tents-camping';
+
+mongoose.connect(dbUrl, {
     useNewUrlParser: true,
     useCreateIndex: true,
     useUnifiedTopology: true


### PR DESCRIPTION
## Summary
- make seeds use the same DB connection string as `app.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683da73e07b48328a9fcfeb393277c24