### PR TITLE
Fix price input feedback markup

### DIFF
--- a/views/campgrounds/edit.ejs
+++ b/views/campgrounds/edit.ejs
@@ -27,7 +27,8 @@
                     <span class="input-group-text" id="price-label">$</span>
                     <input type="text" class="form-control" id="price" placeholder="0.00" aria-label="price"
                         aria-describedby="price-label" name="campground[price]" value="<%=campground.price %>"
-                        required>\<div class="valid-feedback">
+                        required>
+                        <div class="valid-feedback">
                         Looks good!
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix HTML validation markup in campgrounds edit view

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683da74015b48328951a1d593378f790